### PR TITLE
Optimize runtime performance and memory efficiency

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -7,9 +7,9 @@ name: Scala CI
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "master" ]
 
 permissions:
   contents: read
@@ -27,8 +27,7 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: 'sbt'
-    - name: Install sbt
-      run: |
-        curl -fL https://github.com/sbt/sbt/releases/download/v1.8.2/sbt-1.8.2.tgz | tar xz -C /usr/local --strip-components=1
+    - name: Set up sbt
+      uses: sbt/setup-sbt@v1
     - name: Run tests
       run: sbt test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -7,9 +7,9 @@ name: Scala CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
 
 permissions:
   contents: read
@@ -27,5 +27,8 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: 'sbt'
+    - name: Install sbt
+      run: |
+        curl -fL https://github.com/sbt/sbt/releases/download/v1.8.2/sbt-1.8.2.tgz | tar xz -C /usr/local --strip-components=1
     - name: Run tests
       run: sbt test


### PR DESCRIPTION
- FastRP.scala: replace normalize/addVectors/multiplyVectorByScalar with BLAS in-place ops (dscal, daxpy, dnrm2) to eliminate intermediate array allocations and Tuple2 boxing in hot per-edge/per-vertex paths
- FastRP.scala: remove no-op second mapVertices in fastRPPregelImpl (aggrEmbedding is already Array[Double])
- FastRP.scala: replace sortByKey+take with takeOrdered in query_knn (O(N log k) with no shuffle vs O(N log N) full distributed sort)
- FastRP.scala: replace per-iteration checkpoint with persist+periodic checkpoint every 3 iterations + prevGraph.unpersist in fastRPAMImpl, eliminating up to 7 blocking disk-write jobs per run
- Main.scala: replace zipWithIndex header skip with mapPartitionsWithIndex; remove no-op repartition(getNumPartitions); cache scaledData before randomSplit; cache predictionAndLabels before metric computations
- CommonCrawlFastRP.scala: combine two sequential mapVertices for normalization into one while-loop; replace 26 RDD scan jobs from repeated lookup() calls with two collectAsMap() calls + local Map lookups; remove no-op repartition and add scaledData.cache()
- CompanyKGFastRP.scala: remove 3 premature checkpoints on freshly- constructed graph; combine 4-step edge parsing into 1 map; cache edges_base before undirected union; remove coalesce(1) and sortByKey from output path
- CommonCrawlDatasets.scala: replace zipWithIndex header skip with mapPartitionsWithIndex in load_ranks; cache edgesBase before undirected union in load_graph