### PR TITLE
Upgrade to Java 21, Spark 4.0.2, Scala 2.13.18, sbt 1.12.3

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'sbt'
     - name: Set up sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
 
-ThisBuild / scalaVersion := "2.13.11"
+ThisBuild / scalaVersion := "2.13.18"
 // https://mvnrepository.com/artifact/org.apache.spark/spark-graphx
-libraryDependencies += "org.apache.spark" %% "spark-graphx" % "3.4.1"
-// https://mvnrepository.com/artifact/org.apache.spark/spark-graphx
-libraryDependencies += "org.apache.spark" %% "spark-mllib" % "3.4.1"
+libraryDependencies += "org.apache.spark" %% "spark-graphx" % "4.0.2"
+// https://mvnrepository.com/artifact/org.apache.spark/spark-mllib
+libraryDependencies += "org.apache.spark" %% "spark-mllib" % "4.0.2"
 
 lazy val root = (project in file("."))
   .settings(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.2
+sbt.version = 1.12.3


### PR DESCRIPTION
- Scala: 2.13.11 → 2.13.18
- Apache Spark: 3.4.1 → 4.0.2 (spark-graphx, spark-mllib)
- sbt: 1.8.2 → 1.12.3
- CI JDK: 11 → 21 (required by Spark 4.x)

No source code changes needed — GraphX and MLlib RDD-based APIs are unchanged in Spark 4.x.